### PR TITLE
fix: simplify docker-compose.yml for production deployment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,9 +12,9 @@ services:
       # Configuración de PostgreSQL - usar hostname del servicio
       - PG_HOST=postgres
       - PG_PORT=5432
-      - PG_DATABASE=${PG_DATABASE:-invernadero_iot}
-      - PG_USER=${PG_USER:-postgres}
-      - PG_PASSWORD=${PG_PASSWORD:-postgres123}
+      - PG_DATABASE=invernadero_iot
+      - PG_USER=iot_user
+      - PG_PASSWORD=postgres_password
     depends_on:
       postgres:
         condition: service_healthy
@@ -46,13 +46,13 @@ services:
       # Configuración de PostgreSQL - usar hostname del servicio
       - PG_HOST=postgres
       - PG_PORT=5432
-      - PG_DATABASE=${PG_DATABASE:-invernadero_iot}
-      - PG_USER=${PG_USER:-postgres}
-      - PG_PASSWORD=${PG_PASSWORD:-postgres123}
+      - PG_DATABASE=invernadero_iot
+      - PG_USER=iot_user
+      - PG_PASSWORD=postgres_password
       # Configuración de Redis
       - REDIS_HOST=redis
-      - REDIS_PORT=${REDIS_PORT:-6379}
-      - REDIS_PASSWORD=${REDIS_PASSWORD:-redis_password}
+      - REDIS_PORT=6379
+      - REDIS_PASSWORD=redis_password
       # Configuración de MQTT (usando broker externo por defecto)
       - MQTT_BROKER_URL=${MQTT_BROKER_URL:-mqtt://broker.emqx.io}
       - MQTT_USERNAME=${MQTT_USERNAME:-}
@@ -93,9 +93,9 @@ services:
     image: postgres:14-alpine
     container_name: iot-postgres
     environment:
-      - POSTGRES_DB=${PG_DATABASE:-invernadero_iot}
-      - POSTGRES_USER=${PG_USER:-postgres}
-      - POSTGRES_PASSWORD=${PG_PASSWORD:-postgres123}
+      - POSTGRES_DB=invernadero_iot
+      - POSTGRES_USER=iot_user
+      - POSTGRES_PASSWORD=postgres_password
     volumes:
       - postgres_data:/var/lib/postgresql/data
     ports:
@@ -103,23 +103,18 @@ services:
     networks:
       - iot-network
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${PG_USER:-postgres} -d ${PG_DATABASE:-invernadero_iot}"]
+      test: ["CMD-SHELL", "pg_isready -U iot_user -d invernadero_iot"]
       interval: 10s
       timeout: 5s
       retries: 10
       start_period: 30s
+    restart: always
 
   # Redis para Pub/Sub
   redis:
     image: redis:7-alpine
     container_name: iot-redis
-    command: >
-      sh -c "
-      echo 'requirepass redis_password' > /usr/local/etc/redis/redis.conf &&
-      echo 'appendonly yes' >> /usr/local/etc/redis/redis.conf &&
-      echo 'bind 0.0.0.0' >> /usr/local/etc/redis/redis.conf &&
-      redis-server /usr/local/etc/redis/redis.conf
-      "
+    command: redis-server --requirepass redis_password --appendonly yes --bind 0.0.0.0
     ports:
       - "${REDIS_PORT:-6379}:6379"
     volumes:
@@ -128,10 +123,11 @@ services:
       - iot-network
     healthcheck:
       test: ["CMD", "redis-cli", "-a", "redis_password", "ping"]
-      interval: 15s
+      interval: 20s
       timeout: 10s
-      retries: 5
-      start_period: 40s
+      retries: 3
+      start_period: 60s
+    restart: always
 
   # Database management via secure CLI tools only
   # pgAdmin removed for security - use psql or db-cli service for admin tasks


### PR DESCRIPTION
- Replace complex Redis command with simple direct command
- Use hardcoded database credentials instead of environment variables
- Add restart policies to postgres and redis services
- Fix PostgreSQL user from postgres to iot_user
- Use consistent credentials across all services
- Remove shell command complexity that causes exit code 127

This should resolve the Redis container startup issue in easypanel.

🤖 Generated with [Claude Code](https://claude.ai/code)