### PR TITLE
fix: corregir mapeo incorrecto de temperaturaAgua en sensores no acuá…

### DIFF
--- a/src/services/dynamicSensorService.js
+++ b/src/services/dynamicSensorService.js
@@ -613,7 +613,7 @@ class DynamicSensorService {
         ph: normalizedPayload.data.ph || null,
         ec: normalizedPayload.data.ec || null,
         ppm: normalizedPayload.data.ppm || null,
-        temperaturaAgua: normalizedPayload.data.temperature || null,
+        temperaturaAgua: sensor.sensor_type.includes('WATER') ? (normalizedPayload.data.temperature || null) : null,
         
         // Campos adicionales
         rssi: normalizedPayload.rssi,


### PR DESCRIPTION
…ticos

El campo temperaturaAgua se estaba asignando a TODOS los sensores en lugar de solo a sensores de agua. Ahora solo se asigna cuando sensor_type contiene 'WATER'.

Esto evita que sensores como BMP280 (TEMP_PRESSURE) tengan incorrectamente datos de temperatura del agua.

🤖 Generated with [Claude Code](https://claude.ai/code)